### PR TITLE
[Feature Request] Avoid Running Scripts from Directly Online

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,9 @@ If running Ubuntu 20.04 or other distros based on it you must install this dep a
 You must also tell the installer you are running it as well. 
 
 ## Other Deps
+For Ubuntu 16.04 and greater:
+
+`sudo apt install curl md5sum cmake pkg-config git libao-dev libasound2-dev libavcodec-dev libavformat-dev libbluetooth-dev libenet-dev libgtk2.0-dev liblzo2-dev libminiupnpc-dev libopenal-dev libpulse-dev libreadline-dev libsfml-dev libsoil-dev libsoundtouch-dev libswscale-dev libusb-1.0-0-dev libwxbase3.0-dev libwxgtk3.0-dev libxext-dev libxrandr-dev portaudio19-dev zlib1g-dev libudev-dev libevdev-dev "libpolarssl-dev|libmbedtls-dev" libcurl4-openssl-dev libegl1-mesa-dev libpng-dev qtbase5-private-dev`
 
 For most users (including Fedora 24+), see [this page](https://wiki.dolphin-emu.org/index.php?title=Building_Dolphin_on_Linux) for an easy to install list of dependencies; otherwise, see below.
 
@@ -27,7 +30,7 @@ See [attached README, written by fletchers#4892](../other_distros/NixOS/INSTALL.
 
 `sudo eopkg it -c system.devel`
 
-`sudo eopkg it libgtk-2-devel libgtk-3-devel wxwidgets-devel libsm-devel gtest-devel llvm-devel lzo-devel mbedtls-devel miniupnpc-devel libxrandr-devel libxi-devel alsa-lib-devel bluez-devel mesalib-devel curl-devel enet-devel libevdev-devel pulseaudio-devel libusb-devel openal-soft-devel portaudio-devel sdl2-devel SFML-devel soundtouch-devel git cmake pkg-config gcc readline-devel libxext-devel libao-devel`
+`sudo eopkg it libgtk-2-devel libgtk-3-devel wxwidgets-devel libsm-devel gtest-devel llvm-devel lzo-devel mbedtls-devel miniupnpc-devel libxrandr-devel libxi-devel alsa-lib-devel bluez-devel mesalib-devel curl-devel enet-devel libevdev-devel pulseaudio-devel libusb-devel openal-soft-devel portaudio-devel sdl2-devel SFML-devel soundtouch-devel git cmake pkg-config gcc readline-devel libxext-devel libao-devel md5sum`
 
 ## Dependencies Optional
 
@@ -51,14 +54,13 @@ SD card file size 2Gb zipped to 1.6Gb
 ## Instructions: (READ FULLY BEFORE FOLLOWING)
 
 1. Install necessary dependcies listed using guide above. Don't forget that optional deps will bring fast downloads.
-2. Use install script to obtain FPP
-3. Move Brawl into FasterProjectPlus/bin/Games directory
-4. Run the game by opening the .elf file in dolphin
+2. Use install script to obtain FPP.
+3. Move Brawl into FasterProjectPlus/bin/Games directory.
+4. Run the game by opening the .elf file in Ishiiruka.
 
 ## To use:
 
-```sh
-sh -c "$(curl -Ls https://github.com/Birdthulu/FPM-Installer/raw/master/setup)"
+```curl -Ls https://github.com/Birdthulu/FPM-Installer/raw/master/setup && ./setup
 ```
 
 If a different version is needed (e.g. not SL default), edit the script and replace the desired variables.

--- a/README.md
+++ b/README.md
@@ -16,9 +16,7 @@ If running Ubuntu 20.04 or other distros based on it you must install this dep a
 You must also tell the installer you are running it as well. 
 
 ## Other Deps
-For Ubuntu 16.04 and greater:
 
-`sudo apt install curl md5sum cmake pkg-config git libao-dev libasound2-dev libavcodec-dev libavformat-dev libbluetooth-dev libenet-dev libgtk2.0-dev liblzo2-dev libminiupnpc-dev libopenal-dev libpulse-dev libreadline-dev libsfml-dev libsoil-dev libsoundtouch-dev libswscale-dev libusb-1.0-0-dev libwxbase3.0-dev libwxgtk3.0-dev libxext-dev libxrandr-dev portaudio19-dev zlib1g-dev libudev-dev libevdev-dev "libpolarssl-dev|libmbedtls-dev" libcurl4-openssl-dev libegl1-mesa-dev libpng-dev qtbase5-private-dev`
 
 For most users (including Fedora 24+), see [this page](https://wiki.dolphin-emu.org/index.php?title=Building_Dolphin_on_Linux) for an easy to install list of dependencies; otherwise, see below.
 
@@ -30,7 +28,7 @@ See [attached README, written by fletchers#4892](../other_distros/NixOS/INSTALL.
 
 `sudo eopkg it -c system.devel`
 
-`sudo eopkg it libgtk-2-devel libgtk-3-devel wxwidgets-devel libsm-devel gtest-devel llvm-devel lzo-devel mbedtls-devel miniupnpc-devel libxrandr-devel libxi-devel alsa-lib-devel bluez-devel mesalib-devel curl-devel enet-devel libevdev-devel pulseaudio-devel libusb-devel openal-soft-devel portaudio-devel sdl2-devel SFML-devel soundtouch-devel git cmake pkg-config gcc readline-devel libxext-devel libao-devel md5sum`
+`sudo eopkg it libgtk-2-devel libgtk-3-devel wxwidgets-devel libsm-devel gtest-devel llvm-devel lzo-devel mbedtls-devel miniupnpc-devel libxrandr-devel libxi-devel alsa-lib-devel bluez-devel mesalib-devel curl-devel enet-devel libevdev-devel pulseaudio-devel libusb-devel openal-soft-devel portaudio-devel sdl2-devel SFML-devel soundtouch-devel git cmake pkg-config gcc readline-devel libxext-devel libao-devel`
 
 ## Dependencies Optional
 

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ SD card file size 2Gb zipped to 1.6Gb
 
 ## To use:
 
-`curl -Ls https://github.com/Birdthulu/FPM-Installer/raw/master/setup && ./setup`
+`wget https://github.com/Birdthulu/FPM-Installer/raw/master/setup && chmod +x setup && ./setup`
 
 If a different version is needed (e.g. not SL default), edit the script and replace the desired variables.
 

--- a/README.md
+++ b/README.md
@@ -58,8 +58,7 @@ SD card file size 2Gb zipped to 1.6Gb
 
 ## To use:
 
-```curl -Ls https://github.com/Birdthulu/FPM-Installer/raw/master/setup && ./setup
-```
+`curl -Ls https://github.com/Birdthulu/FPM-Installer/raw/master/setup && ./setup`
 
 If a different version is needed (e.g. not SL default), edit the script and replace the desired variables.
 

--- a/setup
+++ b/setup
@@ -6,7 +6,7 @@ set -e
 #
 # --- Based Off of/Ripped from https://github.com/FasterMelee/FasterMelee-installer/ Thank you Faster Melee Team!
 # ---
-ONLINEMASTER=$(curl -Ls https://github.com/ejtejada/FPM-Installer/raw/master/setup | md5sum)
+ONLINEMASTER=$(curl -Ls https://github.com/Birdthulu/FPM-Installer/raw/master/setup | md5sum)
 CURRENTMASTER=$(md5sum setup)
 ##Cut these down to just 32 hex chars
 

--- a/setup
+++ b/setup
@@ -17,7 +17,7 @@ echo $CURRENTMASTER
 if [ -f "./setup" ] && [ "$ONLINEMASTER" != "$CURRENTMASTER" ]; then
 	echo "You are running a out of date copy of this install script. Please *delete the local file 'setup'* and run"
 	echo ""
-	echo "curl -Ls https://github.com/ejtejada/FPM-Installer/raw/master/setup"
+	echo "curl -Ls https://github.com/Birdthulu/FPM-Installer/raw/master/setup"
 	echo ""
 	echo "to ensure you have the latest version!"
 	exit

--- a/setup
+++ b/setup
@@ -10,7 +10,7 @@ set -e
 #If they don't have the setup file, skip the hash check and just continue the script
 if [ -e setup ]
 then
-	ONLINEMASTER=$(curl -Ls https://github.com/ejtejada/FPM-Installer/raw/master/setup | md5sum)
+	ONLINEMASTER=$(curl -Ls https://github.com/Birdthulu/FPM-Installer/raw/master/setup | md5sum)
 	CURRENTMASTER=$(md5sum setup)
 
 	#If they don't have the setup file, skip the hash check and just continue the script

--- a/setup
+++ b/setup
@@ -13,7 +13,7 @@ ONLINEMASTER=${ONLINEMASTER:0:32}
 CURRENTMASTER=${CURRENTMASTER:0:32} 
 echo $ONLINEMASTER
 echo $CURRENTMASTER
-if [ -f "./setup" ] && [ "$ONLINEMASTER" = "$CURRENTMASTER" ]; then
+if [ -f "./setup" ] && [ "$ONLINEMASTER" != "$CURRENTMASTER" ]; then
 	echo "You are running a out of date copy of this install script. Please *delete the local file 'setup'* and run"
 	echo ""
 	echo "curl -Ls https://github.com/Birdthulu/FPM-Installer/raw/master/setup"

--- a/setup
+++ b/setup
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 # --- Stops the script if errors are encountered. ---
 set -e
@@ -9,14 +9,15 @@ set -e
 ONLINEMASTER=$(curl -Ls https://github.com/Birdthulu/FPM-Installer/raw/master/setup | md5sum)
 CURRENTMASTER=$(md5sum setup)
 ##Cut these down to just 32 hex chars
-ONLINEMASTER=${ONLINEMASTER:0:32}
-CURRENTMASTER=${CURRENTMASTER:0:32} 
+
+ONLINEMASTER=$(echo $ONLINEMASTER | cut -c -32)
+CURRENTMASTER=$(echo $CURRENTMASTER | cut -c -32)
 echo $ONLINEMASTER
 echo $CURRENTMASTER
 if [ -f "./setup" ] && [ "$ONLINEMASTER" != "$CURRENTMASTER" ]; then
 	echo "You are running a out of date copy of this install script. Please *delete the local file 'setup'* and run"
 	echo ""
-	echo "curl -Ls https://github.com/Birdthulu/FPM-Installer/raw/master/setup"
+	echo "curl -Ls https://github.com/ejtejada/FPM-Installer/raw/master/setup"
 	echo ""
 	echo "to ensure you have the latest version!"
 	exit

--- a/setup
+++ b/setup
@@ -6,7 +6,7 @@ set -e
 #
 # --- Based Off of/Ripped from https://github.com/FasterMelee/FasterMelee-installer/ Thank you Faster Melee Team!
 # ---
-ONLINEMASTER=$(curl -Ls https://github.com/Birdthulu/FPM-Installer/raw/master/setup | md5sum)
+ONLINEMASTER=$(curl -Ls https://github.com/ejtejada/FPM-Installer/raw/master/setup | md5sum)
 CURRENTMASTER=$(md5sum setup)
 ##Cut these down to just 32 hex chars
 

--- a/setup
+++ b/setup
@@ -6,7 +6,7 @@ set -e
 #
 # --- Based Off of/Ripped from https://github.com/FasterMelee/FasterMelee-installer/ Thank you Faster Melee Team!
 # ---
-ONLINEMASTER=$(curl -Ls https://github.com/ejtejada/FPM-Installer/raw/master/setup | md5sum)
+ONLINEMASTER=$(curl -Ls https://github.com/Birdthulu/FPM-Installer/raw/master/setup | md5sum)
 CURRENTMASTER=$(md5sum setup)
 ##Cut these down to just 32 hex chars
 ONLINEMASTER=${ONLINEMASTER:0:32}

--- a/setup
+++ b/setup
@@ -13,10 +13,7 @@ then
 	ONLINEMASTER=$(curl -Ls https://github.com/Birdthulu/FPM-Installer/raw/master/setup | md5sum)
 	CURRENTMASTER=$(md5sum setup)
 
-	#If they don't have the setup file, skip the hash check and just continue the script
-
 	##Cut these down to just 32 hex chars
-
 	ONLINEMASTER=$(echo $ONLINEMASTER | cut -c -32)
 	CURRENTMASTER=$(echo $CURRENTMASTER | cut -c -32)
 	echo "Online Version:" $ONLINEMASTER

--- a/setup
+++ b/setup
@@ -6,21 +6,31 @@ set -e
 #
 # --- Based Off of/Ripped from https://github.com/FasterMelee/FasterMelee-installer/ Thank you Faster Melee Team!
 # ---
-ONLINEMASTER=$(curl -Ls https://github.com/Birdthulu/FPM-Installer/raw/master/setup | md5sum)
-CURRENTMASTER=$(md5sum setup)
-##Cut these down to just 32 hex chars
 
-ONLINEMASTER=$(echo $ONLINEMASTER | cut -c -32)
-CURRENTMASTER=$(echo $CURRENTMASTER | cut -c -32)
-echo $ONLINEMASTER
-echo $CURRENTMASTER
-if [ -f "./setup" ] && [ "$ONLINEMASTER" != "$CURRENTMASTER" ]; then
-	echo "You are running a out of date copy of this install script. Please *delete the local file 'setup'* and run"
-	echo ""
-	echo "curl -Ls https://github.com/Birdthulu/FPM-Installer/raw/master/setup"
-	echo ""
-	echo "to ensure you have the latest version!"
-	exit
+#If they don't have the setup file, skip the hash check and just continue the script
+if [ -e setup ]
+then
+	ONLINEMASTER=$(curl -Ls https://github.com/ejtejada/FPM-Installer/raw/master/setup | md5sum)
+	CURRENTMASTER=$(md5sum setup)
+
+	#If they don't have the setup file, skip the hash check and just continue the script
+
+	##Cut these down to just 32 hex chars
+
+	ONLINEMASTER=$(echo $ONLINEMASTER | cut -c -32)
+	CURRENTMASTER=$(echo $CURRENTMASTER | cut -c -32)
+	echo "Online Version:" $ONLINEMASTER
+	echo "Your Version:" $CURRENTMASTER
+	if [ -f "./setup" ] && [ "$ONLINEMASTER" != "$CURRENTMASTER" ]; then
+		echo "You are running a out of date copy of this install script. Please delete the local file 'setup' and run"
+		echo ""
+		echo "wget https://github.com/Birdthulu/FPM-Installer/raw/master/setup && chmod +x setup && ./setup"
+		echo ""
+		echo "to ensure you have the latest version!"
+		exit
+	fi
+else
+	echo "No setup script on disk found. Runing script anyway."
 fi
 
 # --- Attempts to determine the number of cores in the CPU. ---

--- a/setup
+++ b/setup
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # --- Stops the script if errors are encountered. ---
 set -e
@@ -6,11 +6,17 @@ set -e
 #
 # --- Based Off of/Ripped from https://github.com/FasterMelee/FasterMelee-installer/ Thank you Faster Melee Team!
 # ---
-
-if [ -f "./setup" ] && [ -z "${IN_NIX_SHELL++}" ]; then
-	echo "You are running a hosted copy of the script. Please *delete the local file 'setup'* and run"
+ONLINEMASTER=$(curl -Ls https://github.com/ejtejada/FPM-Installer/raw/master/setup | md5sum)
+CURRENTMASTER=$(md5sum setup)
+##Cut these down to just 32 hex chars
+ONLINEMASTER=${ONLINEMASTER:0:32}
+CURRENTMASTER=${CURRENTMASTER:0:32} 
+echo $ONLINEMASTER
+echo $CURRENTMASTER
+if [ -f "./setup" ] && [ "$ONLINEMASTER" = "$CURRENTMASTER" ]; then
+	echo "You are running a out of date copy of this install script. Please *delete the local file 'setup'* and run"
 	echo ""
-	echo "sh -c \"\$(curl -Ls https://github.com/Birdthulu/FPM-Installer/raw/master/setup)"
+	echo "curl -Ls https://github.com/Birdthulu/FPM-Installer/raw/master/setup"
 	echo ""
 	echo "to ensure you have the latest version!"
 	exit


### PR DESCRIPTION
Hello Everyone,
This script was awesome, and allowed me to build Ishiiruka for netplay, so thank you!
However, the current way to check if the script is up to date is dangerous. I would never suggest anyone run a script grabbed from curl, as you cannot read it before you run it.
Thus, I changed the check you implemented.
Instead of disallowing the script to run from a downloaded instance, I grab the md5sum of the online master, then compare it to the current one for the existing setup file.
This safely allows a user to just 
./setup
And makes sure they are up to date.
**However**, doing this requires md5sum become a dependency and the shell set to bash (not dash) explicitly. This should causes no issues, but was needed for my string comparison behavior on line 16. I tested these changes to script and it compiled no problem.
I also explicitly stated the dependencies for Ubuntu in the README.
Have a great day,
~Edgar