### PR TITLE
changed '-' in desktop file name to '_', changed Version key to speci…

### DIFF
--- a/setup
+++ b/setup
@@ -325,7 +325,9 @@ sed -i -e "s|ISODirPath|${IsoPath}|" $ConfigPath
 echo "Creating shortcuts..."
 ln -s "$FOLDERNAME/bin/ishiiruka" ../launch-fpp
 if [ "$SHORTCUTBOOL" -eq 1 ] && [ -d ~/.local/share/applications ]; then
+	rm -f ~/.local/share/applications/faster-project-plus-$FPPVERSION.desktop # remove shortcut from older setups
 	rm -f ~/.local/share/applications/faster_project_plus_$FPPVERSION.desktop # remove old shortcut
+	rm -f ~/Desktop/faster-project-plus-$FPPVERSION.desktop # Remove desktop files from previous setups
 	rm -f ~/Desktop/faster_project_plus_$FPPVERSION.desktop
 	touch ~/.local/share/applications/faster_project_plus_$FPPVERSION.desktop # fixes very rare tee bug?
 	EXEPATH="$(pwd)/bin"

--- a/setup
+++ b/setup
@@ -325,9 +325,9 @@ sed -i -e "s|ISODirPath|${IsoPath}|" $ConfigPath
 echo "Creating shortcuts..."
 ln -s "$FOLDERNAME/bin/ishiiruka" ../launch-fpp
 if [ "$SHORTCUTBOOL" -eq 1 ] && [ -d ~/.local/share/applications ]; then
-	rm -f ~/.local/share/applications/faster-project-plus-$FPPVERSION.desktop # remove old shortcut
-	rm -f ~/Desktop/faster-project-plus-$FPPVERSION.desktop
-	touch ~/.local/share/applications/faster-project-plus-$FPPVERSION.desktop # fixes very rare tee bug?
+	rm -f ~/.local/share/applications/faster_project_plus_$FPPVERSION.desktop # remove old shortcut
+	rm -f ~/Desktop/faster_project_plus_$FPPVERSION.desktop
+	touch ~/.local/share/applications/faster_project_plus_$FPPVERSION.desktop # fixes very rare tee bug?
 	EXEPATH="$(pwd)/bin"
 	FPPNAME="Faster Project Plus $FPPVERSION"
 	echo "[Desktop Entry]
@@ -336,12 +336,13 @@ GenericName=Wii/GameCube Emulator
 Comment=Ishiiruka fork for SSBPM
 Categories=Emulator;Game;
 Icon=$EXEPATH/ishiiruka.png
-Keywords=ProjectM;Project M;ProjectPlus;Project Plus;Project+
-Version=$FPPVERSION
+Keywords=ProjectM;Project M;ProjectPlus;Project Plus;Project+;
+Version=1.1
 Name=$FPPNAME
-Exec=$EXEPATH/ishiiruka" | tee ~/.local/share/applications/faster-project-plus-$FPPVERSION.desktop > /dev/null
-	cp ~/.local/share/applications/faster-project-plus-$FPPVERSION.desktop ~/Desktop
-	chmod +x ~/Desktop/faster-project-plus-$FPPVERSION.desktop
+TryExec=$EXEPATH/ishiiruka
+Exec=$EXEPATH/ishiiruka" | tee ~/.local/share/applications/faster_project_plus_$FPPVERSION.desktop > /dev/null
+	cp ~/.local/share/applications/faster_project_plus_$FPPVERSION.desktop ~/Desktop
+	chmod +x ~/Desktop/faster_project_plus_$FPPVERSION.desktop
 else
 	echo ".local folder not found, skipping desktop shortcut."
 fi


### PR DESCRIPTION
…fy Desktop Spec version, added TryExec key

While reading the desktop specification, I saw some small discrepancies between the desktop file being added, and the desktop specification. So, just fixed some things in the setup scripts

## Changes

1. Changed "Version" key to specify Desktop Specification Version, as is needed
2. Added a "TryExec" key with the value being the path of the executable
3. Changed file name of the desktop file to contain underscores instead of dashes, as specified in the Desktop Spec

Quote from the Desktop Specification:

> ...
> Well-known names containing the dash are allowed but not recommended, because the dash is not allowed in some related uses of reversed DNS names, such as D-Bus object paths and interface names, and Flatpak app IDs. If the author's domain name contains a dash, replacing it with an underscore is recommended: this cannot cause ambiguity, because underscores are not allowed in DNS domain names.
> ...

Link to the desktop specification I used: https://specifications.freedesktop.org/desktop-entry-spec/latest/ (As of 26 July 2020)