### PR TITLE
Shell Tweak

### DIFF
--- a/setup
+++ b/setup
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 # --- Stops the script if errors are encountered. ---
 set -e


### PR DESCRIPTION
Changing " #!/bin/sh/ " to " #!/usr/bin/env sh " permits users of terminal shells other than bash, in addition to bash, to run the shell script without issue.
As it previously was, the script could not be run using fish.