### PR TITLE
Fetch correct config for 2.15

### DIFF
--- a/setup
+++ b/setup
@@ -87,7 +87,7 @@ if [ -z "$FPPVERSION" ] || [ -z "$COMMITHASH" ] || [ -z "$GITCLONELINK" ] || [ -
 		FPPVERSION="2.15"
 		CONFIGNAME="fppconfig"
 		COMMITHASH="d6800a124dbba118e297188900d07adfea661b87"
-		CONFIGLINK="https://github.com/Birdthulu/FPM-Installer/raw/master/config/$FPPVERSION-$CONFIGNAME.tar.gz"
+		CONFIGLINK="https://github.com/Birdthulu/FPM-Installer/raw/master/config/legacy/$FPPVERSION-$CONFIGNAME.tar.gz"
 		GITCLONELINK="https://github.com/Birdthulu/Ishiiruka"
 		SdCardFileName="ProjectPlusSdCard215.tar.gz"
 		SdCardDlHash="0anckw4hrxlqn5i"


### PR DESCRIPTION
When 2.2 compatibility was added, the 2.15 config was moved to `config/legacy`, but the setup script wasn't updated to reflect the change. 